### PR TITLE
Support new combined “All Territories (Single File)” option.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,8 @@ A Ruby script to convert the plain text Financial Reports Apple provides to
 App Store developers in iTunes Connect to pretty HTML tables.
 
 Works with Apple's current (as of June 2010) file format and the previous versions
-(pre-Jun 2010 and pre-Feb 2009).
+(pre-Jun 2010 and pre-Feb 2009). Also works with new All Terrotories (Single File)
+download (July 2018).
 
 
 Usage

--- a/itunesconnect2html_template.html.erb
+++ b/itunesconnect2html_template.html.erb
@@ -43,8 +43,31 @@
   <% if total_rows != 0 %>
     <p style="font-weight: bold;">Total Rows: <%= "#{"%.0f" % total_rows}" %></p>
   <% end %>
-  <p style="font-weight: bold;">Total Amount: <%= "#{"%.2f" % total_amount} #{total_amount_currency}" %></p>
+  <% if total_amount != 0 %>
+    <p style="font-weight: bold;">Total Amount: <%= "#{"%.2f" % total_amount} #{total_amount_currency}" %></p>
+  <% end %>
   <% if total_units != 0 %>
     <p style="font-weight: bold;">Total Units: <%= "#{"%.0f" % total_units}" %></p>
   <% end %>
+
+  <% if summary_rows.count != 0 %>
+    <table>
+      <thead>
+        <tr>
+          <% summary_column_headers.each do |column_header| %>
+          <th><%= column_header %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% summary_rows.each do |the_row| %>
+        <tr>
+          <% the_row.each do |field_data| %>
+          <td<%= " style=\"#{field_data[:style]}\"" if field_data[:style] %>><%= field_data[:value] %></td>
+          <% end %>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <% end %>
 </body>


### PR DESCRIPTION
With the launch of App Store Connect, there is now an option to download all reports for a month in a single file. This adds a new summary table to the text file that shows totals per country, rather than a single combined total.

I've modified the code to add this new table to the bottom of the HTML and hide the total amount, as it doesn't appear in the combined report.

I'm not a Ruby dev so apologies if I haven't done something right. I've tested the changes and the old style individual file reports still work (for all cases I've tried).